### PR TITLE
compiler: updates to upstream v0.5.2

### DIFF
--- a/capn-malloc.c
+++ b/capn-malloc.c
@@ -90,6 +90,17 @@ static int read_fp(void *p, size_t sz, FILE *f, struct capn_stream *z, uint8_t* 
 }
 
 static int init_fp(struct capn *c, FILE *f, struct capn_stream *z, int packed) {
+	/*
+	 * Initialize 'c' from the contents of 'f', assuming the message has been
+	 * serialized with the standard framing format. From https://capnproto.org/encoding.html:
+	 *
+	 * When transmitting over a stream, the following should be sent. All integers are unsigned and little-endian.
+	 *   (4 bytes) The number of segments, minus one (since there is always at least one segment).
+	 *   (N * 4 bytes) The size of each segment, in words.
+	 *   (0 or 4 bytes) Padding up to the next word boundary.
+	 *   The content of each segment, in order.
+	 */
+
 	struct capn_segment *s = NULL;
 	uint32_t i, segnum, total = 0;
 	uint32_t hdr[1024];

--- a/compiler/c++.capnp
+++ b/compiler/c++.capnp
@@ -1,27 +1,26 @@
-# Copyright (c) 2013, Kenton Varda <temporal@gmail.com>
-# All rights reserved.
+# Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 @0xbdf87d7bb8304e81;
 $namespace("capnp::annotations");
 
 annotation namespace(file): Text;
+annotation name(field, enumerant, struct, enum, interface, method, param, group, union): Text;

--- a/compiler/schema.capnp
+++ b/compiler/schema.capnp
@@ -1,25 +1,23 @@
-# Copyright (c) 2013, Kenton Varda <temporal@gmail.com>
-# All rights reserved.
+# Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 using Cxx = import "c++.capnp";
 
@@ -49,12 +47,25 @@ struct Node {
   # zero if the node has no parent, which is normally only the case with files, but should be
   # allowed for any kind of node (in order to make runtime type generation easier).
 
+  parameters @32 :List(Parameter);
+  # If this node is parameterized (generic), the list of parameters. Empty for non-generic types.
+
+  isGeneric @33 :Bool;
+  # True if this node is generic, meaning that it or one of its parent scopes has a non-empty
+  # `parameters`.
+
+  struct Parameter {
+    # Information about one of the node's parameters.
+
+    name @0 :Text;
+  }
+
   nestedNodes @4 :List(NestedNode);
   # List of nodes nested within this node, along with the names under which they were declared.
 
   struct NestedNode {
     name @0 :Text;
-    # Unqualified symbol name.  Unlike Node.name, this *can* be used programmatically.
+    # Unqualified symbol name.  Unlike Node.displayName, this *can* be used programmatically.
     #
     # (On Zooko's triangle, this is the node's petname according to its parent scope.)
 
@@ -131,6 +142,9 @@ struct Node {
     interface :group {
       methods @15 :List(Method);
       # Methods ordered by ordinal.
+
+      superclasses @31 :List(Superclass);
+      # Superclasses of this interface.
     }
 
     const :group {
@@ -172,10 +186,11 @@ struct Field {
 
   annotations @2 :List(Annotation);
 
-  discriminantValue @3 :UInt16 = 0xffff;
+  const noDiscriminant :UInt16 = 0xffff;
+
+  discriminantValue @3 :UInt16 = Field.noDiscriminant;
   # If the field is in a union, this is the value which the union's discriminant should take when
-  # the field is active.  If the field is not in a union, this is 0xffff (so hasDiscriminantValue()
-  # returns false).
+  # the field is active.  If the field is not in a union, this is 0xffff.
 
   union {
     slot :group {
@@ -188,6 +203,12 @@ struct Field {
 
       type @5 :Type;
       defaultValue @6 :Value;
+
+      hadExplicitDefault @10 :Bool;
+      # Whether the default value was specified explicitly.  Non-explicit default values are always
+      # zero or empty values.  Usually, whether the default value was explicit shouldn't matter.
+      # The main use case for this flag is for structs representing method parameters:
+      # explicitly-defaulted parameters may be allowed to be omitted when calling the method.
     }
 
     group :group {
@@ -220,6 +241,11 @@ struct Enumerant {
   annotations @2 :List(Annotation);
 }
 
+struct Superclass {
+  id @0 :Id;
+  brand @1 :Brand;
+}
+
 struct Method {
   # Schema for method of an interface.
 
@@ -229,22 +255,29 @@ struct Method {
   # Specifies order in which the methods were declared in the code.
   # Like Struct.Field.codeOrder.
 
-  params @2 :List(Param);
-  struct Param {
-    name @0 :Text;
-    type @1 :Type;
-    defaultValue @2 :Value;
-    annotations @3 :List(Annotation);
-  }
+  implicitParameters @7 :List(Node.Parameter);
+  # The parameters listed in [] (typically, type / generic parameters), whose bindings are intended
+  # to be inferred rather than specified explicitly, although not all languages support this.
 
-  requiredParamCount @3 :UInt16;
-  # One plus the index of the last parameter that has no default value.  In languages where
-  # method calls look like function calls, this is the minimum number of parameters that must
-  # always be specified, while subsequent parameters are optional.
+  paramStructType @2 :Id;
+  # ID of the parameter struct type.  If a named parameter list was specified in the method
+  # declaration (rather than a single struct parameter type) then a corresponding struct type is
+  # auto-generated.  Such an auto-generated type will not be listed in the interface's
+  # `nestedNodes` and its `scopeId` will be zero -- it is completely detached from the namespace.
+  # (Awkwardly, it does of course inherit generic parameters from the method's scope, which makes
+  # this a situation where you can't just climb the scope chain to find where a particular
+  # generic parameter was introduced. Making the `scopeId` zero was a mistake.)
 
-  returnType @4 :Type;
+  paramBrand @5 :Brand;
+  # Brand of param struct type.
 
-  annotations @5 :List(Annotation);
+  resultStructType @3 :Id;
+  # ID of the return struct type; similar to `paramStructType`.
+
+  resultBrand @6 :Brand;
+  # Brand of result struct type.
+
+  annotations @4 :List(Annotation);
 }
 
 struct Type {
@@ -274,15 +307,72 @@ struct Type {
 
     enum :group {
       typeId @15 :Id;
+      brand @21 :Brand;
     }
     struct :group {
       typeId @16 :Id;
+      brand @22 :Brand;
     }
     interface :group {
       typeId @17 :Id;
+      brand @23 :Brand;
     }
 
-    object @18 :Void;
+    anyPointer :union {
+      unconstrained @18 :Void;
+      # A regular AnyPointer.
+
+      parameter :group {
+        # This is actually a reference to a type parameter defined within this scope.
+
+        scopeId @19 :Id;
+        # ID of the generic type whose parameter we're referencing. This should be a parent of the
+        # current scope.
+
+        parameterIndex @20 :UInt16;
+        # Index of the parameter within the generic type's parameter list.
+      }
+
+      implicitMethodParameter :group {
+        # This is actually a reference to an implicit (generic) parameter of a method. The only
+        # legal context for this type to appear is inside Method.paramBrand or Method.resultBrand.
+
+        parameterIndex @24 :UInt16;
+      }
+    }
+  }
+}
+
+struct Brand {
+  # Specifies bindings for parameters of generics. Since these bindings turn a generic into a
+  # non-generic, we call it the "brand".
+
+  scopes @0 :List(Scope);
+  # For each of the target type and each of its parent scopes, a parameterization may be included
+  # in this list. If no parameterization is included for a particular relevant scope, then either
+  # that scope has no parameters or all parameters should be considered to be `AnyPointer`.
+
+  struct Scope {
+    scopeId @0 :Id;
+    # ID of the scope to which these params apply.
+
+    union {
+      bind @1 :List(Binding);
+      # List of parameter bindings.
+
+      inherit @2 :Void;
+      # The place where this Brand appears is actually within this scope or a sub-scope,
+      # and the bindings for this scope should be inherited from the reference point.
+    }
+  }
+
+  struct Binding {
+    union {
+      unbound @0 :Void;
+      type @1 :Type;
+
+      # TODO(someday): Allow non-type parameters? Unsure if useful.
+    }
   }
 }
 
@@ -307,16 +397,16 @@ struct Value {
     text @12 :Text;
     data @13 :Data;
 
-    list @14 :Object;
+    list @14 :AnyPointer;
 
     enum @15 :UInt16;
-    struct @16 :Object;
+    struct @16 :AnyPointer;
 
     interface @17 :Void;
     # The only interface value that can be represented statically is "null", whose methods always
     # throw exceptions.
 
-    object @18 :Object;
+    anyPointer @18 :AnyPointer;
   }
 }
 
@@ -326,6 +416,11 @@ struct Annotation {
 
   id @0 :Id;
   # ID of the annotation node.
+
+  brand @2 :Brand;
+  # Brand of the annotation.
+  #
+  # Note that the annotation itself is not allowed to be parameterized, but its scope might be.
 
   value @1 :Value;
 }

--- a/compiler/schema.capnp.c
+++ b/compiler/schema.capnp.c
@@ -1,15 +1,16 @@
 #include "schema.capnp.h"
 /* AUTO GENERATED - DO NOT EDIT */
 static const capn_text capn_val0 = {0,""};
+uint16_t Field_noDiscriminant = 65535;
 
 Node_ptr new_Node(struct capn_segment *s) {
 	Node_ptr p;
-	p.p = capn_new_struct(s, 40, 5);
+	p.p = capn_new_struct(s, 40, 6);
 	return p;
 }
 Node_list new_Node_list(struct capn_segment *s, int len) {
 	Node_list p;
-	p.p = capn_new_list(s, len, 40, 5);
+	p.p = capn_new_list(s, len, 40, 6);
 	return p;
 }
 void read_Node(struct Node *s, Node_ptr p) {
@@ -18,6 +19,8 @@ void read_Node(struct Node *s, Node_ptr p) {
 	s->displayName = capn_get_text(p.p, 0, capn_val0);
 	s->displayNamePrefixLength = capn_read32(p.p, 8);
 	s->scopeId = capn_read64(p.p, 16);
+	s->parameters.p = capn_getp(p.p, 5, 0);
+	s->isGeneric = (capn_read8(p.p, 36) & 1) != 0;
 	s->nestedNodes.p = capn_getp(p.p, 1, 0);
 	s->annotations.p = capn_getp(p.p, 2, 0);
 	s->which = (enum Node_which) capn_read16(p.p, 12);
@@ -36,6 +39,7 @@ void read_Node(struct Node *s, Node_ptr p) {
 		break;
 	case Node__interface:
 		s->_interface.methods.p = capn_getp(p.p, 3, 0);
+		s->_interface.superclasses.p = capn_getp(p.p, 4, 0);
 		break;
 	case Node__const:
 		s->_const.type.p = capn_getp(p.p, 3, 0);
@@ -66,6 +70,8 @@ void write_Node(const struct Node *s, Node_ptr p) {
 	capn_set_text(p.p, 0, s->displayName);
 	capn_write32(p.p, 8, s->displayNamePrefixLength);
 	capn_write64(p.p, 16, s->scopeId);
+	capn_setp(p.p, 5, s->parameters.p);
+	capn_write1(p.p, 288, s->isGeneric != 0);
 	capn_setp(p.p, 1, s->nestedNodes.p);
 	capn_setp(p.p, 2, s->annotations.p);
 	capn_write16(p.p, 12, s->which);
@@ -84,6 +90,7 @@ void write_Node(const struct Node *s, Node_ptr p) {
 		break;
 	case Node__interface:
 		capn_setp(p.p, 3, s->_interface.methods.p);
+		capn_setp(p.p, 4, s->_interface.superclasses.p);
 		break;
 	case Node__const:
 		capn_setp(p.p, 3, s->_const.type.p);
@@ -117,6 +124,35 @@ void set_Node(const struct Node *s, Node_list l, int i) {
 	Node_ptr p;
 	p.p = capn_getp(l.p, i, 0);
 	write_Node(s, p);
+}
+
+Node_Parameter_ptr new_Node_Parameter(struct capn_segment *s) {
+	Node_Parameter_ptr p;
+	p.p = capn_new_struct(s, 0, 1);
+	return p;
+}
+Node_Parameter_list new_Node_Parameter_list(struct capn_segment *s, int len) {
+	Node_Parameter_list p;
+	p.p = capn_new_list(s, len, 0, 1);
+	return p;
+}
+void read_Node_Parameter(struct Node_Parameter *s, Node_Parameter_ptr p) {
+	capn_resolve(&p.p);
+	s->name = capn_get_text(p.p, 0, capn_val0);
+}
+void write_Node_Parameter(const struct Node_Parameter *s, Node_Parameter_ptr p) {
+	capn_resolve(&p.p);
+	capn_set_text(p.p, 0, s->name);
+}
+void get_Node_Parameter(struct Node_Parameter *s, Node_Parameter_list l, int i) {
+	Node_Parameter_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	read_Node_Parameter(s, p);
+}
+void set_Node_Parameter(const struct Node_Parameter *s, Node_Parameter_list l, int i) {
+	Node_Parameter_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	write_Node_Parameter(s, p);
 }
 
 Node_NestedNode_ptr new_Node_NestedNode(struct capn_segment *s) {
@@ -172,6 +208,7 @@ void read_Field(struct Field *s, Field_ptr p) {
 		s->slot.offset = capn_read32(p.p, 4);
 		s->slot.type.p = capn_getp(p.p, 2, 0);
 		s->slot.defaultValue.p = capn_getp(p.p, 3, 0);
+		s->slot.hadExplicitDefault = (capn_read8(p.p, 16) & 1) != 0;
 		break;
 	case Field_group:
 		s->group.typeId = capn_read64(p.p, 16);
@@ -200,6 +237,7 @@ void write_Field(const struct Field *s, Field_ptr p) {
 		capn_write32(p.p, 4, s->slot.offset);
 		capn_setp(p.p, 2, s->slot.type.p);
 		capn_setp(p.p, 3, s->slot.defaultValue.p);
+		capn_write1(p.p, 128, s->slot.hadExplicitDefault != 0);
 		break;
 	case Field_group:
 		capn_write64(p.p, 16, s->group.typeId);
@@ -260,33 +298,68 @@ void set_Enumerant(const struct Enumerant *s, Enumerant_list l, int i) {
 	write_Enumerant(s, p);
 }
 
+Superclass_ptr new_Superclass(struct capn_segment *s) {
+	Superclass_ptr p;
+	p.p = capn_new_struct(s, 8, 1);
+	return p;
+}
+Superclass_list new_Superclass_list(struct capn_segment *s, int len) {
+	Superclass_list p;
+	p.p = capn_new_list(s, len, 8, 1);
+	return p;
+}
+void read_Superclass(struct Superclass *s, Superclass_ptr p) {
+	capn_resolve(&p.p);
+	s->id = capn_read64(p.p, 0);
+	s->brand.p = capn_getp(p.p, 0, 0);
+}
+void write_Superclass(const struct Superclass *s, Superclass_ptr p) {
+	capn_resolve(&p.p);
+	capn_write64(p.p, 0, s->id);
+	capn_setp(p.p, 0, s->brand.p);
+}
+void get_Superclass(struct Superclass *s, Superclass_list l, int i) {
+	Superclass_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	read_Superclass(s, p);
+}
+void set_Superclass(const struct Superclass *s, Superclass_list l, int i) {
+	Superclass_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	write_Superclass(s, p);
+}
+
 Method_ptr new_Method(struct capn_segment *s) {
 	Method_ptr p;
-	p.p = capn_new_struct(s, 8, 4);
+	p.p = capn_new_struct(s, 24, 5);
 	return p;
 }
 Method_list new_Method_list(struct capn_segment *s, int len) {
 	Method_list p;
-	p.p = capn_new_list(s, len, 8, 4);
+	p.p = capn_new_list(s, len, 24, 5);
 	return p;
 }
 void read_Method(struct Method *s, Method_ptr p) {
 	capn_resolve(&p.p);
 	s->name = capn_get_text(p.p, 0, capn_val0);
 	s->codeOrder = capn_read16(p.p, 0);
-	s->params.p = capn_getp(p.p, 1, 0);
-	s->requiredParamCount = capn_read16(p.p, 2);
-	s->returnType.p = capn_getp(p.p, 2, 0);
-	s->annotations.p = capn_getp(p.p, 3, 0);
+	s->implicitParameters.p = capn_getp(p.p, 4, 0);
+	s->paramStructType = capn_read64(p.p, 8);
+	s->paramBrand.p = capn_getp(p.p, 2, 0);
+	s->resultStructType = capn_read64(p.p, 16);
+	s->resultBrand.p = capn_getp(p.p, 3, 0);
+	s->annotations.p = capn_getp(p.p, 1, 0);
 }
 void write_Method(const struct Method *s, Method_ptr p) {
 	capn_resolve(&p.p);
 	capn_set_text(p.p, 0, s->name);
 	capn_write16(p.p, 0, s->codeOrder);
-	capn_setp(p.p, 1, s->params.p);
-	capn_write16(p.p, 2, s->requiredParamCount);
-	capn_setp(p.p, 2, s->returnType.p);
-	capn_setp(p.p, 3, s->annotations.p);
+	capn_setp(p.p, 4, s->implicitParameters.p);
+	capn_write64(p.p, 8, s->paramStructType);
+	capn_setp(p.p, 2, s->paramBrand.p);
+	capn_write64(p.p, 16, s->resultStructType);
+	capn_setp(p.p, 3, s->resultBrand.p);
+	capn_setp(p.p, 1, s->annotations.p);
 }
 void get_Method(struct Method *s, Method_list l, int i) {
 	Method_ptr p;
@@ -299,49 +372,14 @@ void set_Method(const struct Method *s, Method_list l, int i) {
 	write_Method(s, p);
 }
 
-Method_Param_ptr new_Method_Param(struct capn_segment *s) {
-	Method_Param_ptr p;
-	p.p = capn_new_struct(s, 0, 4);
-	return p;
-}
-Method_Param_list new_Method_Param_list(struct capn_segment *s, int len) {
-	Method_Param_list p;
-	p.p = capn_new_list(s, len, 0, 4);
-	return p;
-}
-void read_Method_Param(struct Method_Param *s, Method_Param_ptr p) {
-	capn_resolve(&p.p);
-	s->name = capn_get_text(p.p, 0, capn_val0);
-	s->type.p = capn_getp(p.p, 1, 0);
-	s->defaultValue.p = capn_getp(p.p, 2, 0);
-	s->annotations.p = capn_getp(p.p, 3, 0);
-}
-void write_Method_Param(const struct Method_Param *s, Method_Param_ptr p) {
-	capn_resolve(&p.p);
-	capn_set_text(p.p, 0, s->name);
-	capn_setp(p.p, 1, s->type.p);
-	capn_setp(p.p, 2, s->defaultValue.p);
-	capn_setp(p.p, 3, s->annotations.p);
-}
-void get_Method_Param(struct Method_Param *s, Method_Param_list l, int i) {
-	Method_Param_ptr p;
-	p.p = capn_getp(l.p, i, 0);
-	read_Method_Param(s, p);
-}
-void set_Method_Param(const struct Method_Param *s, Method_Param_list l, int i) {
-	Method_Param_ptr p;
-	p.p = capn_getp(l.p, i, 0);
-	write_Method_Param(s, p);
-}
-
 Type_ptr new_Type(struct capn_segment *s) {
 	Type_ptr p;
-	p.p = capn_new_struct(s, 16, 1);
+	p.p = capn_new_struct(s, 24, 1);
 	return p;
 }
 Type_list new_Type_list(struct capn_segment *s, int len) {
 	Type_list p;
-	p.p = capn_new_list(s, len, 16, 1);
+	p.p = capn_new_list(s, len, 24, 1);
 	return p;
 }
 void read_Type(struct Type *s, Type_ptr p) {
@@ -353,12 +391,29 @@ void read_Type(struct Type *s, Type_ptr p) {
 		break;
 	case Type__enum:
 		s->_enum.typeId = capn_read64(p.p, 8);
+		s->_enum.brand.p = capn_getp(p.p, 0, 0);
 		break;
 	case Type__struct:
 		s->_struct.typeId = capn_read64(p.p, 8);
+		s->_struct.brand.p = capn_getp(p.p, 0, 0);
 		break;
 	case Type__interface:
 		s->_interface.typeId = capn_read64(p.p, 8);
+		s->_interface.brand.p = capn_getp(p.p, 0, 0);
+		break;
+	case Type_anyPointer:
+		s->anyPointer_which = (enum Type_anyPointer_which) capn_read16(p.p, 8);
+		switch (s->anyPointer_which) {
+		case Type_anyPointer_parameter:
+			s->anyPointer.parameter.scopeId = capn_read64(p.p, 16);
+			s->anyPointer.parameter.parameterIndex = capn_read16(p.p, 10);
+			break;
+		case Type_anyPointer_implicitMethodParameter:
+			s->anyPointer.implicitMethodParameter.parameterIndex = capn_read16(p.p, 10);
+			break;
+		default:
+			break;
+		}
 		break;
 	default:
 		break;
@@ -373,12 +428,29 @@ void write_Type(const struct Type *s, Type_ptr p) {
 		break;
 	case Type__enum:
 		capn_write64(p.p, 8, s->_enum.typeId);
+		capn_setp(p.p, 0, s->_enum.brand.p);
 		break;
 	case Type__struct:
 		capn_write64(p.p, 8, s->_struct.typeId);
+		capn_setp(p.p, 0, s->_struct.brand.p);
 		break;
 	case Type__interface:
 		capn_write64(p.p, 8, s->_interface.typeId);
+		capn_setp(p.p, 0, s->_interface.brand.p);
+		break;
+	case Type_anyPointer:
+		capn_write16(p.p, 8, s->anyPointer_which);
+		switch (s->anyPointer_which) {
+		case Type_anyPointer_parameter:
+			capn_write64(p.p, 16, s->anyPointer.parameter.scopeId);
+			capn_write16(p.p, 10, s->anyPointer.parameter.parameterIndex);
+			break;
+		case Type_anyPointer_implicitMethodParameter:
+			capn_write16(p.p, 10, s->anyPointer.implicitMethodParameter.parameterIndex);
+			break;
+		default:
+			break;
+		}
 		break;
 	default:
 		break;
@@ -393,6 +465,123 @@ void set_Type(const struct Type *s, Type_list l, int i) {
 	Type_ptr p;
 	p.p = capn_getp(l.p, i, 0);
 	write_Type(s, p);
+}
+
+Brand_ptr new_Brand(struct capn_segment *s) {
+	Brand_ptr p;
+	p.p = capn_new_struct(s, 0, 1);
+	return p;
+}
+Brand_list new_Brand_list(struct capn_segment *s, int len) {
+	Brand_list p;
+	p.p = capn_new_list(s, len, 0, 1);
+	return p;
+}
+void read_Brand(struct Brand *s, Brand_ptr p) {
+	capn_resolve(&p.p);
+	s->scopes.p = capn_getp(p.p, 0, 0);
+}
+void write_Brand(const struct Brand *s, Brand_ptr p) {
+	capn_resolve(&p.p);
+	capn_setp(p.p, 0, s->scopes.p);
+}
+void get_Brand(struct Brand *s, Brand_list l, int i) {
+	Brand_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	read_Brand(s, p);
+}
+void set_Brand(const struct Brand *s, Brand_list l, int i) {
+	Brand_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	write_Brand(s, p);
+}
+
+Brand_Scope_ptr new_Brand_Scope(struct capn_segment *s) {
+	Brand_Scope_ptr p;
+	p.p = capn_new_struct(s, 16, 1);
+	return p;
+}
+Brand_Scope_list new_Brand_Scope_list(struct capn_segment *s, int len) {
+	Brand_Scope_list p;
+	p.p = capn_new_list(s, len, 16, 1);
+	return p;
+}
+void read_Brand_Scope(struct Brand_Scope *s, Brand_Scope_ptr p) {
+	capn_resolve(&p.p);
+	s->scopeId = capn_read64(p.p, 0);
+	s->which = (enum Brand_Scope_which) capn_read16(p.p, 8);
+	switch (s->which) {
+	case Brand_Scope_bind:
+		s->bind.p = capn_getp(p.p, 0, 0);
+		break;
+	default:
+		break;
+	}
+}
+void write_Brand_Scope(const struct Brand_Scope *s, Brand_Scope_ptr p) {
+	capn_resolve(&p.p);
+	capn_write64(p.p, 0, s->scopeId);
+	capn_write16(p.p, 8, s->which);
+	switch (s->which) {
+	case Brand_Scope_bind:
+		capn_setp(p.p, 0, s->bind.p);
+		break;
+	default:
+		break;
+	}
+}
+void get_Brand_Scope(struct Brand_Scope *s, Brand_Scope_list l, int i) {
+	Brand_Scope_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	read_Brand_Scope(s, p);
+}
+void set_Brand_Scope(const struct Brand_Scope *s, Brand_Scope_list l, int i) {
+	Brand_Scope_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	write_Brand_Scope(s, p);
+}
+
+Brand_Binding_ptr new_Brand_Binding(struct capn_segment *s) {
+	Brand_Binding_ptr p;
+	p.p = capn_new_struct(s, 8, 1);
+	return p;
+}
+Brand_Binding_list new_Brand_Binding_list(struct capn_segment *s, int len) {
+	Brand_Binding_list p;
+	p.p = capn_new_list(s, len, 8, 1);
+	return p;
+}
+void read_Brand_Binding(struct Brand_Binding *s, Brand_Binding_ptr p) {
+	capn_resolve(&p.p);
+	s->which = (enum Brand_Binding_which) capn_read16(p.p, 0);
+	switch (s->which) {
+	case Brand_Binding_type:
+		s->type.p = capn_getp(p.p, 0, 0);
+		break;
+	default:
+		break;
+	}
+}
+void write_Brand_Binding(const struct Brand_Binding *s, Brand_Binding_ptr p) {
+	capn_resolve(&p.p);
+	capn_write16(p.p, 0, s->which);
+	switch (s->which) {
+	case Brand_Binding_type:
+		capn_setp(p.p, 0, s->type.p);
+		break;
+	default:
+		break;
+	}
+}
+void get_Brand_Binding(struct Brand_Binding *s, Brand_Binding_list l, int i) {
+	Brand_Binding_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	read_Brand_Binding(s, p);
+}
+void set_Brand_Binding(const struct Brand_Binding *s, Brand_Binding_list l, int i) {
+	Brand_Binding_ptr p;
+	p.p = capn_getp(l.p, i, 0);
+	write_Brand_Binding(s, p);
 }
 
 Value_ptr new_Value(struct capn_segment *s) {
@@ -439,8 +628,8 @@ void read_Value(struct Value *s, Value_ptr p) {
 		break;
 	case Value__list:
 	case Value__struct:
-	case Value_object:
-		s->object = capn_getp(p.p, 0, 0);
+	case Value_anyPointer:
+		s->anyPointer = capn_getp(p.p, 0, 0);
 		break;
 	default:
 		break;
@@ -480,8 +669,8 @@ void write_Value(const struct Value *s, Value_ptr p) {
 		break;
 	case Value__list:
 	case Value__struct:
-	case Value_object:
-		capn_setp(p.p, 0, s->object);
+	case Value_anyPointer:
+		capn_setp(p.p, 0, s->anyPointer);
 		break;
 	default:
 		break;
@@ -500,22 +689,24 @@ void set_Value(const struct Value *s, Value_list l, int i) {
 
 Annotation_ptr new_Annotation(struct capn_segment *s) {
 	Annotation_ptr p;
-	p.p = capn_new_struct(s, 8, 1);
+	p.p = capn_new_struct(s, 8, 2);
 	return p;
 }
 Annotation_list new_Annotation_list(struct capn_segment *s, int len) {
 	Annotation_list p;
-	p.p = capn_new_list(s, len, 8, 1);
+	p.p = capn_new_list(s, len, 8, 2);
 	return p;
 }
 void read_Annotation(struct Annotation *s, Annotation_ptr p) {
 	capn_resolve(&p.p);
 	s->id = capn_read64(p.p, 0);
+	s->brand.p = capn_getp(p.p, 1, 0);
 	s->value.p = capn_getp(p.p, 0, 0);
 }
 void write_Annotation(const struct Annotation *s, Annotation_ptr p) {
 	capn_resolve(&p.p);
 	capn_write64(p.p, 0, s->id);
+	capn_setp(p.p, 1, s->brand.p);
 	capn_setp(p.p, 0, s->value.p);
 }
 void get_Annotation(struct Annotation *s, Annotation_list l, int i) {

--- a/compiler/test.capnp
+++ b/compiler/test.capnp
@@ -1,25 +1,23 @@
-# Copyright (c) 2013, Kenton Varda <temporal@gmail.com>
-# All rights reserved.
+# Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 @0xd508eebdc2dc42b8;
 
@@ -92,7 +90,7 @@ struct TestDefaults {
   float32Field   @10 : Float32 = 1234.5;
   float64Field   @11 : Float64 = -123e45;
   textField      @12 : Text    = "foo";
-  dataField      @13 : Data    = "bar";
+  dataField      @13 : Data    = 0x"62 61 72"; # "bar"
   structField    @14 : TestAllTypes = (
       voidField      = void,
       boolField      = true,
@@ -160,10 +158,10 @@ struct TestDefaults {
   interfaceList @33 : List(Void);  # TODO
 }
 
-struct TestObject {
-  objectField @0 :Object;
+struct TestAnyPointer {
+  anyPointerField @0 :AnyPointer;
 
-  # Do not add any other fields here!  Some tests rely on objectField being the last pointer
+  # Do not add any other fields here!  Some tests rely on anyPointerField being the last pointer
   # in the struct.
 }
 
@@ -476,9 +474,134 @@ struct TestNewVersion {
 
 struct TestStructUnion {
   un @0! :union {
-    allTypes @1 :TestAllTypes;
-    object @2 :TestObject;
+    struct @1 :SomeStruct;
+    object @2 :TestAnyPointer;
   }
+
+  struct SomeStruct {
+    someText @0 :Text;
+    moreText @1 :Text;
+  }
+}
+
+struct TestPrintInlineStructs {
+  someText @0 :Text;
+
+  structList @1 :List(InlineStruct);
+  struct InlineStruct {
+    int32Field @0 :Int32;
+    textField @1 :Text;
+  }
+}
+
+struct TestWholeFloatDefault {
+  # At one point, these failed to compile in C++ because it would produce literals like "123f",
+  # which is not valid; it needs to be "123.0f".
+  field @0 :Float32 = 123;
+  bigField @1 :Float32 = 2e30;
+  const constant :Float32 = 456;
+  const bigConstant :Float32 = 4e30;
+}
+
+struct TestGenerics(Foo, Bar) {
+  foo @0 :Foo;
+  rev @1 :TestGenerics(Bar, Foo);
+
+  struct Inner {
+    foo @0 :Foo;
+    bar @1 :Bar;
+  }
+
+  struct Inner2(Baz) {
+    bar @0 :Bar;
+    baz @1 :Baz;
+    innerBound @2 :Inner;
+    innerUnbound @3 :TestGenerics.Inner;
+
+    struct DeepNest(Qux) {
+      foo @0 :Foo;
+      bar @1 :Bar;
+      baz @2 :Baz;
+      qux @3 :Qux;
+    }
+  }
+
+  interface Interface(Qux) {
+    call @0 Inner2(Text) -> (qux :Qux, gen :TestGenerics(TestAllTypes, TestAnyPointer));
+  }
+
+  annotation ann(struct) :Foo;
+
+  using AliasFoo = Foo;
+  using AliasInner = Inner;
+  using AliasInner2 = Inner2;
+  using AliasInner2Text = Inner2(Text);
+  using AliasRev = TestGenerics(Bar, Foo);
+
+  struct UseAliases {
+    foo @0 :AliasFoo;
+    inner @1 :AliasInner;
+    inner2 @2 :AliasInner2;
+    inner2Bind @3 :AliasInner2(Text);
+    inner2Text @4 :AliasInner2Text;
+    revFoo @5 :AliasRev.AliasFoo;
+  }
+}
+
+struct TestGenericsWrapper(Foo, Bar) {
+  value @0 :TestGenerics(Foo, Bar);
+}
+
+struct TestGenericsWrapper2 {
+  value @0 :TestGenericsWrapper(Text, TestAllTypes);
+}
+
+interface TestImplicitMethodParams {
+  call @0 [T, U] (foo :T, bar :U) -> TestGenerics(T, U);
+}
+
+interface TestImplicitMethodParamsInGeneric(V) {
+  call @0 [T, U] (foo :T, bar :U) -> TestGenerics(T, U);
+}
+
+struct TestUseGenerics $TestGenerics(Text, Data).ann("foo") {
+  basic @0 :TestGenerics(TestAllTypes, TestAnyPointer);
+  inner @1 :TestGenerics(TestAllTypes, TestAnyPointer).Inner;
+  inner2 @2 :TestGenerics(TestAllTypes, TestAnyPointer).Inner2(Text);
+  unspecified @3 :TestGenerics;
+  unspecifiedInner @4 :TestGenerics.Inner2(Text);
+  wrapper @8 :TestGenericsWrapper(TestAllTypes, TestAnyPointer);
+  cap @18 :TestGenerics(TestInterface, Text);
+  genericCap @19 :TestGenerics(TestAllTypes, List(UInt32)).Interface(Data);
+
+  default @5 :TestGenerics(TestAllTypes, Text) =
+      (foo = (int16Field = 123), rev = (foo = "text", rev = (foo = (int16Field = 321))));
+  defaultInner @6 :TestGenerics(TestAllTypes, Text).Inner =
+      (foo = (int16Field = 123), bar = "text");
+  defaultUser @7 :TestUseGenerics = (basic = (foo = (int16Field = 123)));
+  defaultWrapper @9 :TestGenericsWrapper(Text, TestAllTypes) =
+      (value = (foo = "text", rev = (foo = (int16Field = 321))));
+  defaultWrapper2 @10 :TestGenericsWrapper2 =
+      (value = (value = (foo = "text", rev = (foo = (int16Field = 321)))));
+
+  aliasFoo @11 :TestGenerics(TestAllTypes, TestAnyPointer).AliasFoo = (int16Field = 123);
+  aliasInner @12 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner
+      = (foo = (int16Field = 123));
+  aliasInner2 @13 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner2
+      = (innerBound = (foo = (int16Field = 123)));
+  aliasInner2Bind @14 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner2(List(UInt32))
+      = (baz = [12, 34], innerBound = (foo = (int16Field = 123)));
+  aliasInner2Text @15 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner2Text
+      = (baz = "text", innerBound = (foo = (int16Field = 123)));
+  aliasRev @16 :TestGenerics(TestAnyPointer, Text).AliasRev.AliasFoo = "text";
+
+  useAliases @17 :TestGenerics(TestAllTypes, List(UInt32)).UseAliases = (
+      foo = (int16Field = 123),
+      inner = (foo = (int16Field = 123)),
+      inner2 = (innerBound = (foo = (int16Field = 123))),
+      inner2Bind = (baz = "text", innerBound = (foo = (int16Field = 123))),
+      inner2Text = (baz = "text", innerBound = (foo = (int16Field = 123))),
+      revFoo = [12, 34, 56]);
 }
 
 struct TestEmptyStruct {}
@@ -566,9 +689,164 @@ struct TestConstants {
 const globalInt :UInt32 = 12345;
 const globalText :Text = "foobar";
 const globalStruct :TestAllTypes = (int32Field = 54321);
+const globalPrintableStruct :TestPrintInlineStructs = (someText = "foo");
 const derivedConstant :TestAllTypes = (
     uInt32Field = .globalInt,
     textField = TestConstants.textConst,
     structField = TestConstants.structConst,
     int16List = TestConstants.int16ListConst,
     structList = TestConstants.structListConst);
+
+const genericConstant :TestGenerics(TestAllTypes, Text) =
+    (foo = (int16Field = 123), rev = (foo = "text", rev = (foo = (int16Field = 321))));
+
+interface TestInterface {
+  foo @0 (i :UInt32, j :Bool) -> (x :Text);
+  bar @1 () -> ();
+  baz @2 (s: TestAllTypes);
+}
+
+interface TestExtends extends(TestInterface) {
+  qux @0 ();
+  corge @1 TestAllTypes -> ();
+  grault @2 () -> TestAllTypes;
+}
+
+interface TestExtends2 extends(TestExtends) {}
+
+interface TestPipeline {
+  getCap @0 (n: UInt32, inCap :TestInterface) -> (s: Text, outBox :Box);
+  testPointers @1 (cap :TestInterface, obj :AnyPointer, list :List(TestInterface)) -> ();
+
+  struct Box {
+    cap @0 :TestInterface;
+  }
+}
+
+interface TestCallOrder {
+  getCallSequence @0 (expected: UInt32) -> (n: UInt32);
+  # First call returns 0, next returns 1, ...
+  #
+  # The input `expected` is ignored but useful for disambiguating debug logs.
+}
+
+interface TestTailCallee {
+  struct TailResult {
+    i @0 :UInt32;
+    t @1 :Text;
+    c @2 :TestCallOrder;
+  }
+
+  foo @0 (i :Int32, t :Text) -> TailResult;
+}
+
+interface TestTailCaller {
+  foo @0 (i :Int32, callee :TestTailCallee) -> TestTailCallee.TailResult;
+}
+
+interface TestHandle {}
+
+interface TestMoreStuff extends(TestCallOrder) {
+  # Catch-all type that contains lots of testing methods.
+
+  callFoo @0 (cap :TestInterface) -> (s: Text);
+  # Call `cap.foo()`, check the result, and return "bar".
+
+  callFooWhenResolved @1 (cap :TestInterface) -> (s: Text);
+  # Like callFoo but waits for `cap` to resolve first.
+
+  neverReturn @2 (cap :TestInterface) -> (capCopy :TestInterface);
+  # Doesn't return.  You should cancel it.
+
+  hold @3 (cap :TestInterface) -> ();
+  # Returns immediately but holds on to the capability.
+
+  callHeld @4 () -> (s: Text);
+  # Calls the capability previously held using `hold` (and keeps holding it).
+
+  getHeld @5 () -> (cap :TestInterface);
+  # Returns the capability previously held using `hold` (and keeps holding it).
+
+  echo @6 (cap :TestCallOrder) -> (cap :TestCallOrder);
+  # Just returns the input cap.
+
+  expectCancel @7 (cap :TestInterface) -> ();
+  # evalLater()-loops forever, holding `cap`.  Must be canceled.
+
+  methodWithDefaults @8 (a :Text, b :UInt32 = 123, c :Text = "foo") -> (d :Text, e :Text = "bar");
+
+  getHandle @9 () -> (handle :TestHandle);
+  # Get a new handle. Tests have an out-of-band way to check the current number of live handles, so
+  # this can be used to test garbage collection.
+}
+
+interface TestKeywordMethods {
+  delete @0 ();
+  class @1 ();
+  void @2 ();
+  return @3 ();
+}
+
+struct TestSturdyRef {
+  hostId @0 :TestSturdyRefHostId;
+  objectId @1 :AnyPointer;
+}
+
+struct TestSturdyRefHostId {
+  host @0 :Text;
+}
+
+struct TestSturdyRefObjectId {
+  tag @0 :Tag;
+  enum Tag {
+    testInterface @0;
+    testExtends @1;
+    testPipeline @2;
+    testTailCallee @3;
+    testTailCaller @4;
+    testMoreStuff @5;
+  }
+}
+
+struct TestProvisionId {}
+struct TestRecipientId {}
+struct TestThirdPartyCapId {}
+struct TestJoinResult {}
+
+struct TestNameAnnotation $Cxx.name("RenamedStruct") {
+  union {
+    badFieldName @0 :Bool $Cxx.name("goodFieldName");
+    bar @1 :Int8;
+  }
+
+  enum BadlyNamedEnum $Cxx.name("RenamedEnum") {
+    foo @0;
+    bar @1;
+    baz @2 $Cxx.name("qux");
+  }
+
+  anotherBadFieldName @2 :BadlyNamedEnum $Cxx.name("anotherGoodFieldName");
+
+  struct NestedStruct $Cxx.name("RenamedNestedStruct") {
+    badNestedFieldName @0 :Bool $Cxx.name("goodNestedFieldName");
+    anotherBadNestedFieldName @1 :NestedStruct $Cxx.name("anotherGoodNestedFieldName");
+
+    enum DeeplyNestedEnum $Cxx.name("RenamedDeeplyNestedEnum") {
+      quux @0;
+      corge @1;
+      grault @2 $Cxx.name("garply");
+    }
+  }
+
+  badlyNamedUnion :union $Cxx.name("renamedUnion") {
+    badlyNamedGroup :group $Cxx.name("renamedGroup") {
+      foo @3 :Void;
+      bar @4 :Void;
+    }
+    baz @5 :NestedStruct $Cxx.name("qux");
+  }
+}
+
+interface TestNameAnnotationInterface $Cxx.name("RenamedInterface") {
+  badlyNamedMethod @0 (badlyNamedParam :UInt8 $Cxx.name("renamedParam")) $Cxx.name("renamedMethod");
+}

--- a/compiler/update-notes.md
+++ b/compiler/update-notes.md
@@ -1,0 +1,18 @@
+
+occasionally, it may be required to sync with upstream capn proto changes. some quick notes on the process i've used here, assuming the updated capnproto repo is at CAPNP_CPP:
+
+    $ cp ${CAPNP_CPP}/c++/src/capnp/test.capnp .
+    $ cp ${CAPNP_CPP}/c++/src/capnp/schema.capnp .
+    $ cp ${CAPNP_CPP}/c++/src/capnp/c++.capnp .
+
+fix up `schema.capnp` to reference the in-tree copy of `c++.capnp` (ie, `using Cxx = import "c++.capnp";` at the top of the file)
+
+then, regenerate the schema support:
+
+    $ capnp compile -o ./capnpc-c compiler/schema.capnp
+
+now try to regenerate again, based on the previously regenerated schema.
+
+you can always check the capnpc formatted output during debugging:
+
+    $ capnp compile -ocapnpc-capnpc compiler/schema.capnp


### PR DESCRIPTION
can now run against the `capnp` tool v0.5.2, fixes an issue in which it would previously fail with `cant find node with id 0xNNN`
